### PR TITLE
Feature/omit path prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Options:
   --datadir, -d  feed data directory, if ommited RAM memory will be used[string]
   --output, -o   log output directory or file, if not provided output will be
                  logged to console.                                     [string]
+  --prefix, -p   path prefix to be omitted                              [string]
   --console, -c  log output to console, if output provided and console ommited
                  then output would be logged only in file!             [boolean]
   --tail         tail the log file                                     [boolean]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Options:
   --datadir, -d  feed data directory, if ommited RAM memory will be used[string]
   --output, -o   log output directory or file, if not provided output will be
                  logged to console.                                     [string]
-  --prefix, -p   path prefix to be omitted                              [string]
+  --remote-prefix, -rp   path prefix to be omitted                              [string]
   --console, -c  log output to console, if output provided and console ommited
                  then output would be logged only in file!             [boolean]
   --tail         tail the log file                                     [boolean]

--- a/bin/hyperlog.js
+++ b/bin/hyperlog.js
@@ -179,7 +179,8 @@ const main = async () => {
     const client = new HyperCoreLogReader(storage, key, null, null, streamOpts)
 
     client.on('data', async (data) => {
-      const line = data.toString().trimRight().replace(prefixRegExp, '')
+      const originLine = data.toString().trimRight()
+      const line = prefixRegExp ? originLine.replace(prefixRegExp, '') : originLine
 
       if (logConsole) console.log(line)
 

--- a/bin/hyperlog.js
+++ b/bin/hyperlog.js
@@ -5,7 +5,7 @@
 process.env.DEBUG = 'hcore-logger'
 
 const fs = require('fs')
-const { join, dirname, basename } = require('path')
+const { join, dirname, basename, normalize } = require('path')
 const ram = require('random-access-memory')
 const pkg = require('../package.json')
 const yargs = require('yargs')
@@ -28,6 +28,11 @@ const yargs = require('yargs')
         alias: 'o',
         description: 'log output directory or file, if not provided output ' +
           'will be logged to console.'
+      })
+      .option('prefix', {
+        type: 'string',
+        alias: 'p',
+        description: 'path prefix to be omitted'
       })
       .option('console', {
         type: 'boolean',
@@ -163,6 +168,7 @@ const main = async () => {
     if (!key) throw new Error('ERR_KEY_REQUIRED')
 
     const logConsole = argv.output ? argv.console : true
+    const prefixRegExp = argv.prefix ? new RegExp(`^${normalize(argv.prefix)}`) : null
     const { path: destination, file, demultiplex } = argv.output ? await prepareOutputDestination(argv.output) : {}
 
     let streamOpts = {}
@@ -173,7 +179,7 @@ const main = async () => {
     const client = new HyperCoreLogReader(storage, key, null, null, streamOpts)
 
     client.on('data', async (data) => {
-      const line = data.toString().trimRight()
+      const line = data.toString().trimRight().replace(prefixRegExp, '')
 
       if (logConsole) console.log(line)
 

--- a/bin/hyperlog.js
+++ b/bin/hyperlog.js
@@ -29,9 +29,9 @@ const yargs = require('yargs')
         description: 'log output directory or file, if not provided output ' +
           'will be logged to console.'
       })
-      .option('prefix', {
+      .option('remote-prefix', {
         type: 'string',
-        alias: 'p',
+        alias: 'rp',
         description: 'path prefix to be omitted'
       })
       .option('console', {
@@ -168,7 +168,7 @@ const main = async () => {
     if (!key) throw new Error('ERR_KEY_REQUIRED')
 
     const logConsole = argv.output ? argv.console : true
-    const prefixRegExp = argv.prefix ? new RegExp(`^${normalize(argv.prefix)}`) : null
+    const prefixRegExp = argv['remote-prefix'] ? new RegExp(`^${normalize(argv['remote-prefix'])}`) : null
     const { path: destination, file, demultiplex } = argv.output ? await prepareOutputDestination(argv.output) : {}
 
     let streamOpts = {}


### PR DESCRIPTION
### Changes:

- Added optional `prefix` option

If the prefix option is specified and start of the path from the original logs matches, it will be omitted