### PR TITLE
Fix performance

### DIFF
--- a/src/hypercore-file-logger.js
+++ b/src/hypercore-file-logger.js
@@ -138,7 +138,10 @@ class HyperCoreFileLogger extends HyperCoreLogger {
 
   async start () {
     await super.start()
-    this.watcher = chokidar.watch(this.pathlike)
+    this.watcher = chokidar.watch(this.pathlike, {
+      usePolling: true,
+      interval: 300
+    })
 
     this.watcher.on('ready', () => { this.isReady = true })
     this.watcher.on('add', file => this.watchFile(file, {


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1200252479009184/1201528609517679

### Changes:

- enable `usePolling` option for Chokidar

### Tests (performed with the [Benchmark system](https://github.com/bitfinexcom/hypercore-logs/pull/8))

#### 1. v0.4.0

 `npm i https://github.com/bitfinexcom/hypercore-logs#v0.4.0`

10k requests in 10.03s, 1.26 MB read
```
┌─────────┬──────┬──────┬───────┬───────┬─────────┬─────────┬───────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg     │ Stdev   │ Max   │
├─────────┼──────┼──────┼───────┼───────┼─────────┼─────────┼───────┤
│ Latency │ 7 ms │ 9 ms │ 16 ms │ 19 ms │ 9.32 ms │ 2.64 ms │ 40 ms │
└─────────┴──────┴──────┴───────┴───────┴─────────┴─────────┴───────┘
┌───────────┬─────────┬─────────┬────────┬────────┬────────┬─────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%    │ 97.5%  │ Avg    │ Stdev   │ Min     │
├───────────┼─────────┼─────────┼────────┼────────┼────────┼─────────┼─────────┤
│ Req/Sec   │ 736     │ 736     │ 1049   │ 1151   │ 1015.8 │ 147.97  │ 736     │
├───────────┼─────────┼─────────┼────────┼────────┼────────┼─────────┼─────────┤
│ Bytes/Sec │ 91.3 kB │ 91.3 kB │ 130 kB │ 143 kB │ 126 kB │ 18.4 kB │ 91.3 kB │
└───────────┴─────────┴─────────┴────────┴────────┴────────┴─────────┴─────────┘
```
![image](https://user-images.githubusercontent.com/70510980/147249563-e8519aed-4f4b-4961-968f-04f6584672e5.png)


#### 2. master branch

 `npm i https://github.com/bitfinexcom/hypercore-logs#master`

510 requests in 10.02s, 62 kB read
```
┌─────────┬────────┬────────┬────────┬────────┬───────────┬──────────┬────────┐
│ Stat    │ 2.5%   │ 50%    │ 97.5%  │ 99%    │ Avg       │ Stdev    │ Max    │
├─────────┼────────┼────────┼────────┼────────┼───────────┼──────────┼────────┤
│ Latency │ 172 ms │ 196 ms │ 272 ms │ 317 ms │ 198.65 ms │ 32.99 ms │ 317 ms │
└─────────┴────────┴────────┴────────┴────────┴───────────┴──────────┴────────┘
┌───────────┬─────────┬─────────┬────────┬─────────┬────────┬───────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%    │ 97.5%   │ Avg    │ Stdev │ Min     │
├───────────┼─────────┼─────────┼────────┼─────────┼────────┼───────┼─────────┤
│ Req/Sec   │ 40      │ 40      │ 50     │ 60      │ 50     │ 4.48  │ 40      │
├───────────┼─────────┼─────────┼────────┼─────────┼────────┼───────┼─────────┤
│ Bytes/Sec │ 4.96 kB │ 4.96 kB │ 6.2 kB │ 7.44 kB │ 6.2 kB │ 555 B │ 4.96 kB │
└───────────┴─────────┴─────────┴────────┴─────────┴────────┴───────┴─────────┘
```
![image](https://user-images.githubusercontent.com/70510980/147218694-910cf3b3-5f7b-492a-88a2-62a9542b8099.png)

#### 3. [fix/watch-files-performance](https://github.com/vitaliystoliarovcc/hypercore-logs/tree/fix/watch-files-performance)
 `npm i https://github.com/vitaliystoliarovcc/hypercore-logs#fix/watch-files-performance`

10k requests in 10.02s, 1.2 MB read
```
┌─────────┬──────┬──────┬───────┬───────┬─────────┬─────────┬───────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg     │ Stdev   │ Max   │
├─────────┼──────┼──────┼───────┼───────┼─────────┼─────────┼───────┤
│ Latency │ 7 ms │ 9 ms │ 18 ms │ 24 ms │ 9.81 ms │ 3.98 ms │ 90 ms │
└─────────┴──────┴──────┴───────┴───────┴─────────┴─────────┴───────┘
┌───────────┬─────────┬─────────┬────────┬────────┬────────┬─────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%    │ 97.5%  │ Avg    │ Stdev   │ Min     │
├───────────┼─────────┼─────────┼────────┼────────┼────────┼─────────┼─────────┤
│ Req/Sec   │ 682     │ 682     │ 1035   │ 1162   │ 969.7  │ 182.83  │ 682     │
├───────────┼─────────┼─────────┼────────┼────────┼────────┼─────────┼─────────┤
│ Bytes/Sec │ 84.6 kB │ 84.6 kB │ 128 kB │ 144 kB │ 120 kB │ 22.7 kB │ 84.6 kB │
└───────────┴─────────┴─────────┴────────┴────────┴────────┴─────────┴─────────┘
```
![image](https://user-images.githubusercontent.com/70510980/147250288-187417f9-bc0f-488b-b34e-ee3eb57c9263.png)

