### PR TITLE
Fix tail performance

### DIFF
--- a/benchmarks/tests/tail.js
+++ b/benchmarks/tests/tail.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const http = require('http')
+const path = require('path')
+const fs = require('fs')
+const { HyperCoreFileLogger } = require('hypercore-logs')
+
+const cwd = process.cwd()
+const feedDir = path.join(cwd, '/tmp/data')
+const key = '0db350f414a93274e5613930b79c7226f21270cfc1435b96350422a0abf63dc2'
+const secretKey = 'f66a2bbec992b9d4c3dfadc67b8aa69782334ae7753fce182' +
+  '016e06c80b6d0dd0db350f414a93274e5613930b' +
+  '79c7226f21270cfc1435b96350422a0abf63dc2'
+
+const tailfile = path.join(cwd, 'file.log')
+const server = new HyperCoreFileLogger(tailfile, true, feedDir, key, { secretKey })
+
+const main = async () => {
+  const file = await fs.promises.open('file.log', 'w')
+
+  await file.write('')
+
+  http.createServer(async (request, response) => {
+    file.appendFile(`${Math.random()}\n`)
+
+    response.end('ok')
+  }).listen(3000)
+
+  await server.start()
+}
+
+main()

--- a/src/hypercore-file-logger.js
+++ b/src/hypercore-file-logger.js
@@ -114,7 +114,7 @@ class HyperCoreFileLogger extends HyperCoreLogger {
       }
     }
 
-    const tail = new Tail(file)
+    const tail = new Tail(file, { useWatchFile: true })
     tail.on('line', (line) => {
       const data = HyperCoreFileLogger.formatLine(line, options.multiple && file) + '\n'
       this.feed.append(data)


### PR DESCRIPTION
## benchmarks/tests/tail.js results

### master branch: 19k requests
```
┌─────────┬──────┬──────┬───────┬───────┬────────┬─────────┬───────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg    │ Stdev   │ Max   │
├─────────┼──────┼──────┼───────┼───────┼────────┼─────────┼───────┤
│ Latency │ 2 ms │ 4 ms │ 12 ms │ 16 ms │ 4.7 ms │ 2.81 ms │ 45 ms │
└─────────┴──────┴──────┴───────┴───────┴────────┴─────────┴───────┘
┌───────────┬────────┬────────┬────────┬────────┬────────┬────────┬────────┐
│ Stat      │ 1%     │ 2.5%   │ 50%    │ 97.5%  │ Avg    │ Stdev  │ Min    │
├───────────┼────────┼────────┼────────┼────────┼────────┼────────┼────────┤
│ Req/Sec   │ 1117   │ 1117   │ 2041   │ 2343   │ 1916.9 │ 435.95 │ 1117   │
├───────────┼────────┼────────┼────────┼────────┼────────┼────────┼────────┤
│ Bytes/Sec │ 139 kB │ 139 kB │ 253 kB │ 291 kB │ 238 kB │ 54 kB  │ 139 kB │
└───────────┴────────┴────────┴────────┴────────┴────────┴────────┴────────┘

Req/Bytes counts sampled once per second.

19k requests in 10.04s, 2.38 MB read
```

### useWatchFile is true: 23k
```
┌─────────┬──────┬──────┬───────┬───────┬─────────┬─────────┬───────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg     │ Stdev   │ Max   │
├─────────┼──────┼──────┼───────┼───────┼─────────┼─────────┼───────┤
│ Latency │ 2 ms │ 3 ms │ 11 ms │ 14 ms │ 3.76 ms │ 2.43 ms │ 45 ms │
└─────────┴──────┴──────┴───────┴───────┴─────────┴─────────┴───────┘
┌───────────┬────────┬────────┬────────┬────────┬─────────┬─────────┬────────┐
│ Stat      │ 1%     │ 2.5%   │ 50%    │ 97.5%  │ Avg     │ Stdev   │ Min    │
├───────────┼────────┼────────┼────────┼────────┼─────────┼─────────┼────────┤
│ Req/Sec   │ 1304   │ 1304   │ 2577   │ 2805   │ 2346.31 │ 527.73  │ 1304   │
├───────────┼────────┼────────┼────────┼────────┼─────────┼─────────┼────────┤
│ Bytes/Sec │ 162 kB │ 162 kB │ 319 kB │ 348 kB │ 291 kB  │ 65.4 kB │ 162 kB │
└───────────┴────────┴────────┴────────┴────────┴─────────┴─────────┴────────┘

Req/Bytes counts sampled once per second.

23k requests in 10.03s, 2.91 MB read
```


### idle test (without HyperCoreFileLogger): 29k requests
```
┌─────────┬──────┬──────┬───────┬───────┬─────────┬─────────┬───────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%   │ Avg     │ Stdev   │ Max   │
├─────────┼──────┼──────┼───────┼───────┼─────────┼─────────┼───────┤
│ Latency │ 1 ms │ 3 ms │ 8 ms  │ 11 ms │ 3.33 ms │ 1.98 ms │ 31 ms │
└─────────┴──────┴──────┴───────┴───────┴─────────┴─────────┴───────┘
┌───────────┬────────┬────────┬────────┬────────┬─────────┬────────┬────────┐
│ Stat      │ 1%     │ 2.5%   │ 50%    │ 97.5%  │ Avg     │ Stdev  │ Min    │
├───────────┼────────┼────────┼────────┼────────┼─────────┼────────┼────────┤
│ Req/Sec   │ 1544   │ 1544   │ 2885   │ 3063   │ 2598.82 │ 532.44 │ 1544   │
├───────────┼────────┼────────┼────────┼────────┼─────────┼────────┼────────┤
│ Bytes/Sec │ 191 kB │ 191 kB │ 358 kB │ 380 kB │ 322 kB  │ 66 kB  │ 191 kB │
└───────────┴────────┴────────┴────────┴────────┴─────────┴────────┴────────┘

Req/Bytes counts sampled once per second.

29k requests in 11.03s, 3.54 MB read
```
